### PR TITLE
Setup Redis session with internal JWT auth

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,6 +23,11 @@ spec:
               value: "redis"
             - name: SPRING_DATA_REDIS_PORT
               value: "6379"
+            - name: JWT_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: jwt-secret
+                  key: JWT_SECRET_KEY
             - name: GOOGLE_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/src/main/java/com/shuttleverse/gateway/config/JwtConfig.java
+++ b/src/main/java/com/shuttleverse/gateway/config/JwtConfig.java
@@ -1,0 +1,37 @@
+package com.shuttleverse.gateway.config;
+
+import com.nimbusds.jose.jwk.source.ImmutableSecret;
+import java.nio.charset.StandardCharsets;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+
+@Configuration
+public class JwtConfig {
+
+  @Value("${jwt.secret}")
+  private String secretKey;
+
+  @Bean
+  public JwtEncoder jwtEncoder() {
+    SecretKey key = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+
+    return new NimbusJwtEncoder(new ImmutableSecret<>(key));
+  }
+
+  @Bean
+  public JwtDecoder jwtDecoder() {
+    SecretKey key = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+
+    return NimbusJwtDecoder.withSecretKey(key)
+        .macAlgorithm(MacAlgorithm.HS256)
+        .build();
+  }
+}

--- a/src/main/java/com/shuttleverse/gateway/config/SecurityConfig.java
+++ b/src/main/java/com/shuttleverse/gateway/config/SecurityConfig.java
@@ -2,86 +2,46 @@ package com.shuttleverse.gateway.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
-import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientProvider;
-import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientProviderBuilder;
-import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
-import org.springframework.security.oauth2.client.web.DefaultReactiveOAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.web.server.DefaultServerOAuth2AuthorizationRequestResolver;
-import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizationRequestResolver;
-import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizedClientRepository;
-import org.springframework.security.oauth2.client.web.server.WebSessionServerOAuth2AuthorizedClientRepository;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.context.WebSessionServerSecurityContextRepository;
+import reactor.core.publisher.Mono;
 
 @Configuration
 @EnableWebFluxSecurity
 public class SecurityConfig {
 
   @Bean
-  public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http,
-      ServerOAuth2AuthorizationRequestResolver authorizationRequestResolver) {
+  public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
     http
         .csrf(ServerHttpSecurity.CsrfSpec::disable)
         .authorizeExchange(exchanges -> exchanges
             .pathMatchers("/actuator/**", "/fallback/**").permitAll()
-            .pathMatchers("/login", "/oauth2/**").permitAll()
+            .pathMatchers("/auth/login", "/oauth2/**").permitAll()
             .anyExchange().authenticated()
         )
         .oauth2Login(oauth2 -> oauth2
-            .authorizedClientRepository(authorizedClientRepository())
-            .authorizationRequestResolver(authorizationRequestResolver)
+            .authenticationFailureHandler((exchange, exception) ->
+                Mono.fromRunnable(() -> exchange.getExchange().getResponse()
+                    .setStatusCode(HttpStatus.UNAUTHORIZED)))
         )
         .oauth2Client(Customizer.withDefaults())
-        // Store the security context in the web session
-        .securityContextRepository(new WebSessionServerSecurityContextRepository());
+        .exceptionHandling(exceptions -> exceptions
+            .authenticationEntryPoint((exchange, exception) ->
+                Mono.fromRunnable(
+                    () -> exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED)))
+        )
+        .securityContextRepository(new WebSessionServerSecurityContextRepository())
+        .logout(logout -> logout
+            .logoutUrl("/auth/logout")
+            .logoutSuccessHandler((exchange, authentication) -> {
+              exchange.getExchange().getResponse().setStatusCode(HttpStatus.OK);
+              return Mono.empty();
+            }));
 
     return http.build();
-  }
-
-  @Bean
-  public ServerOAuth2AuthorizationRequestResolver authorizationRequestResolver(
-      ReactiveClientRegistrationRepository clientRegistrationRepository) {
-
-    DefaultServerOAuth2AuthorizationRequestResolver resolver =
-        new DefaultServerOAuth2AuthorizationRequestResolver(
-            clientRegistrationRepository);
-
-    resolver.setAuthorizationRequestCustomizer(builder -> {
-      builder.additionalParameters(params -> {
-        params.put("access_type", "offline");
-        params.put("prompt", "consent");
-      });
-    });
-
-    return resolver;
-  }
-
-  @Bean
-  public ServerOAuth2AuthorizedClientRepository authorizedClientRepository() {
-    return new WebSessionServerOAuth2AuthorizedClientRepository();
-  }
-
-  @Bean
-  public ReactiveOAuth2AuthorizedClientManager authorizedClientManager(
-      ReactiveClientRegistrationRepository clientRegistrationRepository,
-      ServerOAuth2AuthorizedClientRepository authorizedClientRepository) {
-
-    ReactiveOAuth2AuthorizedClientProvider authorizedClientProvider =
-        ReactiveOAuth2AuthorizedClientProviderBuilder.builder()
-            .authorizationCode()
-            .refreshToken()
-            .build();
-
-    DefaultReactiveOAuth2AuthorizedClientManager manager =
-        new DefaultReactiveOAuth2AuthorizedClientManager(
-            clientRegistrationRepository, authorizedClientRepository);
-
-    manager.setAuthorizedClientProvider(authorizedClientProvider);
-
-    return manager;
   }
 }

--- a/src/main/java/com/shuttleverse/gateway/config/SessionConfig.java
+++ b/src/main/java/com/shuttleverse/gateway/config/SessionConfig.java
@@ -37,8 +37,8 @@ public class SessionConfig {
   @Bean
   public WebSessionIdResolver webSessionIdResolver() {
     CookieWebSessionIdResolver resolver = new CookieWebSessionIdResolver();
-    resolver.setCookieName("GATEWAY_SESSION");
-    resolver.setCookieMaxAge(Duration.ofMinutes(30));
+    resolver.setCookieName("SHUTTLEVERSE_SESSION");
+    resolver.setCookieMaxAge(Duration.ofDays(1));
     resolver.addCookieInitializer(responseCookieBuilder ->
         responseCookieBuilder
             .path("/")

--- a/src/main/java/com/shuttleverse/gateway/controller/AuthController.java
+++ b/src/main/java/com/shuttleverse/gateway/controller/AuthController.java
@@ -1,0 +1,49 @@
+package com.shuttleverse.gateway.controller;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+  @GetMapping("/login")
+  public Mono<Void> login(ServerWebExchange exchange) {
+    return Mono.fromRunnable(() -> {
+      ServerHttpResponse response = exchange.getResponse();
+      response.setStatusCode(HttpStatus.FOUND);
+      response.getHeaders().setLocation(URI.create("/oauth2/authorization/google"));
+    });
+  }
+
+  @GetMapping("/user")
+  public Mono<Map<String, Object>> getUserInfo(ServerWebExchange exchange) {
+    return exchange.getPrincipal()
+        .filter(principal -> principal instanceof OAuth2AuthenticationToken)
+        .cast(OAuth2AuthenticationToken.class)
+        .map(token -> {
+          if (token.getPrincipal() instanceof OidcUser oidcUser) {
+            Map<String, Object> userInfo = new HashMap<>();
+            userInfo.put("id", oidcUser.getSubject());
+            userInfo.put("email", oidcUser.getEmail());
+            userInfo.put("name", oidcUser.getFullName());
+            return userInfo;
+          }
+          return Collections.<String, Object>emptyMap();
+        })
+        .switchIfEmpty(Mono.just(Collections.emptyMap()));
+  }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,30 @@
+spring:
+  cloud:
+    gateway:
+      default-filters:
+        - SaveSession
+      discovery:
+        locator:
+          enabled: true
+          lower-case-service-id: true
+
+      # Route definitions
+      routes:
+        - id: shuttleverse-aggregator
+          uri: http://localhost:8080
+          predicates:
+            - Path=/api/aggregator/**
+
+        - id: shuttleverse-community
+          uri: http://localhost:8083
+          predicates:
+            - Path=/api/community/**
+
+eureka:
+  client:
+    service-url:
+      defaultZone: "http://localhost:8761/eureka/"
+    register-with-eureka: false
+    fetch-registry: false
+  instance:
+    prefer-ip-address: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,13 +7,13 @@ spring:
 
   data:
     redis:
-      host: ${SPRING_DATA_REDIS_HOST}
-      port: ${SPRING_DATA_REDIS_PORT}
+      host: ${SPRING_DATA_REDIS_HOST:localhost}
+      port: ${SPRING_DATA_REDIS_PORT:6379}
   session:
     redis:
       namespace: "shuttleverse:session"
       flush-mode: on-save
-    timeout: 30m
+    timeout: 24h
 
   # OAuth2 Configuration
   security:
@@ -51,6 +51,11 @@ spring:
           uri: lb://shuttleverse-community
           predicates:
             - Path=/api/community/**
+  profiles:
+    default: dev
+
+jwt:
+  secret: ${JWT_SECRET_KEY}
 
 eureka:
   client:


### PR DESCRIPTION
# Changes 
- Modified auth flow from using Google's open ID --> internal JWT generation and authentication
- Changed behavior of authentication flow: 
   - `Unauthenticated requests --> 401` instead of redirecting to authentication flow 
   - `/auth/login` initializes the authentication flow 
   - `/auth/logout` removes the session 
   - `/auth/user` gives basic information on authenticated user 